### PR TITLE
애플 소셜로그인 구현

### DIFF
--- a/module-api/src/main/java/com/junior/security/JwtUtil.java
+++ b/module-api/src/main/java/com/junior/security/JwtUtil.java
@@ -1,15 +1,25 @@
 package com.junior.security;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.junior.dto.jwt.LoginCreateJwtDto;
+import com.junior.exception.JwtErrorException;
+import com.junior.exception.StatusCode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
+import java.security.PublicKey;
 import java.sql.Timestamp;
+import java.util.Base64;
 import java.util.Date;
+import java.util.Map;
 
 @Component
 public class JwtUtil {
@@ -48,8 +58,8 @@ public class JwtUtil {
         Date expireDate = Timestamp.valueOf(loginCreateJwtDto.requestTimeMs());
 
 
-        if(category.equals("access")){
-            expireDate=Timestamp.valueOf(loginCreateJwtDto.requestTimeMs().plusHours(1));
+        if (category.equals("access")) {
+            expireDate = Timestamp.valueOf(loginCreateJwtDto.requestTimeMs().plusHours(1));
         } else if (category.equals("refresh")) {
             expireDate = Timestamp.valueOf(loginCreateJwtDto.requestTimeMs().plusMonths(6));
         }
@@ -63,5 +73,51 @@ public class JwtUtil {
                 .expiration(expireDate)
                 .signWith(secretKey)
                 .compact();
+    }
+
+
+    /**
+     * JWT의 헤더를 꺼내는 기능
+     * @param token
+     * @return JWT's header
+     * @throws JsonProcessingException
+     */
+    public Map<String, String> parseHeaders(String token) throws JsonProcessingException {
+
+        //JWT를 .을 기준으로 header, payload, signature 분리 -> 그 중 header 선택
+        String header = token.split("\\.")[0];
+
+        //header를 디코딩 및 매핑하여 리턴
+        return new ObjectMapper().readValue(decodeHeader(header), Map.class);
+    }
+
+    /**
+     * JWT를 Base64 디코딩
+     * @param token
+     * @return
+     */
+    private String decodeHeader(String token) {
+        return new String(Base64.getDecoder().decode(token), StandardCharsets.UTF_8);
+    }
+
+
+    /**
+     * 토큰과 PK를 사용하여 Claim 리턴
+     * @param token
+     * @param publicKey
+     * @return
+     */
+    public Claims getTokenClaims(String token, PublicKey publicKey) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(publicKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+        } catch (MalformedJwtException e) {
+            throw new JwtErrorException(StatusCode.INVALID_TOKEN);
+        } catch (ExpiredJwtException e) {
+            throw new JwtErrorException(StatusCode.EXPIRED_ACCESS_TOKEN);
+        }
     }
 }

--- a/module-api/src/main/java/com/junior/security/generator/ApplePublicKeyGenerator.java
+++ b/module-api/src/main/java/com/junior/security/generator/ApplePublicKeyGenerator.java
@@ -1,0 +1,60 @@
+package com.junior.security.generator;
+
+import com.junior.dto.oauth2.ApplePublicKey;
+import com.junior.dto.oauth2.ApplePublicKeyResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.stereotype.Component;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class ApplePublicKeyGenerator {
+
+    /**
+     *
+     * @param tokenHeaders: 애플 로그인 id_token의 헤더
+     * @param applePublicKeys: appleid.apple.com으로 요청해서 받아온 3개의 PK 리스트
+     * @return
+     * @throws AuthenticationException
+     * @throws NoSuchAlgorithmException
+     * @throws InvalidKeySpecException
+     */
+    public PublicKey generatePublicKey(Map<String, String> tokenHeaders, ApplePublicKeyResponse applePublicKeys)
+            throws AuthenticationException, NoSuchAlgorithmException, InvalidKeySpecException {
+
+        //3개의 PK 중 tokenHeaders의 kid, alg와 같은 key를 리턴
+        ApplePublicKey publicKey = applePublicKeys.getMatchedKey(tokenHeaders.get("kid"), tokenHeaders.get("alg"));
+
+        //해당 키의 n, e를 가져와 PK 생성
+        return getPublicKey(publicKey);
+    }
+
+    /**
+     * RSA 알고리즘 -> kty, n, e를 이용한 PK 생성
+     * @param publicKey
+     * @return
+     * @throws NoSuchAlgorithmException
+     * @throws InvalidKeySpecException
+     */
+    private PublicKey getPublicKey(ApplePublicKey publicKey)
+            throws NoSuchAlgorithmException, InvalidKeySpecException {
+        byte[] nBytes = Base64.getUrlDecoder().decode(publicKey.n());
+        byte[] eBytes = Base64.getUrlDecoder().decode(publicKey.e());
+
+        RSAPublicKeySpec publicKeySpec = new RSAPublicKeySpec(new BigInteger(1, nBytes),
+                new BigInteger(1, eBytes));
+
+
+        KeyFactory keyFactory = KeyFactory.getInstance(publicKey.kty());
+        return keyFactory.generatePublic(publicKeySpec);
+    }
+}

--- a/module-api/src/main/java/com/junior/service/comment/CommentService.java
+++ b/module-api/src/main/java/com/junior/service/comment/CommentService.java
@@ -55,14 +55,14 @@ public class CommentService {
             comment.updateParent(parentComment);
 
             // 부모 댓글 작성자 != 자식댓글 작성자 -> 알림 생성
-            if(!parentComment.getMember().getId().equals(findMember.getId()))
+            if (!parentComment.getMember().getId().equals(findMember.getId()))
                 notificationService.saveNotification(parentComment.getMember(), findMember.getProfileImage(), comment.getContent(), findStory.getId(), NotificationType.COMMENT);
         }
 
         commentRepository.save(comment);
 
         // 스토리 작성자 != 댓글 작성자 -> 알림 생성
-        if(!findStory.getMember().getId().equals(findMember.getId()))
+        if (!findStory.getMember().getId().equals(findMember.getId()))
             notificationService.saveNotification(findStory.getMember(), findMember.getProfileImage(), comment.getContent(), findStory.getId(), NotificationType.COMMENT);
     }
 

--- a/module-api/src/main/java/com/junior/service/story/MemberStoryService.java
+++ b/module-api/src/main/java/com/junior/service/story/MemberStoryService.java
@@ -103,7 +103,7 @@ public class MemberStoryService {
         Story findStory = storyRepository.findById(storyId)
                 .orElseThrow(() -> new StoryNotFoundException(StatusCode.STORY_NOT_FOUND));
 
-        if(findStory.getIsDeleted()) {
+        if (findStory.getIsDeleted()) {
             throw new DeletedStoryException(StatusCode.STORY_DELETED);
         }
 
@@ -145,7 +145,7 @@ public class MemberStoryService {
             findStory.increaseLikeCnt();
 
             //좋아요 누른 사람 != 스토리 주인 -> 알림 저장
-            if(!findStory.getMember().getId().equals(findMember.getId()))
+            if (!findStory.getMember().getId().equals(findMember.getId()))
                 notificationService.saveNotification(findStory.getMember(), findMember.getProfileImage(), findStory.getTitle(), findStory.getId(), NotificationType.LIKED);
 
         } else {

--- a/module-api/src/main/java/com/junior/strategy/oauth2/AppleOAuth2LoginStrategy.java
+++ b/module-api/src/main/java/com/junior/strategy/oauth2/AppleOAuth2LoginStrategy.java
@@ -1,0 +1,101 @@
+package com.junior.strategy.oauth2;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.junior.dto.oauth2.ApplePublicKeyResponse;
+import com.junior.dto.oauth2.OAuth2LoginDto;
+import com.junior.dto.oauth2.OAuth2Provider;
+import com.junior.dto.oauth2.OAuth2UserInfo;
+import com.junior.exception.CustomException;
+import com.junior.exception.JwtErrorException;
+import com.junior.exception.StatusCode;
+import com.junior.security.JwtUtil;
+import com.junior.security.generator.ApplePublicKeyGenerator;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Map;
+
+import static com.junior.dto.oauth2.OAuth2Provider.APPLE;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AppleOAuth2LoginStrategy implements OAuth2MemberStrategy {
+
+    private final ApplePublicKeyGenerator applePublicKeyGenerator;
+    private final JwtUtil jwtUtil;
+    @Value("${oauth2.apple.client-id}")
+    private String clientId;
+    @Value("${oauth2.apple.pk-host}")
+    private String pkHost;
+
+    //LoginDto에 토큰이 담겨있어야 함
+    @Override
+    public OAuth2UserInfo getOAuth2UserInfo(OAuth2LoginDto oAuth2LoginDto) {
+        String appleAccountId = getAppleAccountId(oAuth2LoginDto.id());
+
+
+        return OAuth2UserInfo.builder()
+                .id(appleAccountId)
+                .nickname(oAuth2LoginDto.nickname())
+                .provider(APPLE).build();
+    }
+
+    @Override
+    public boolean isTarget(OAuth2Provider oAuth2Provider) {
+        return oAuth2Provider.equals(APPLE);
+    }
+
+
+    private String getAppleAccountId(String identityToken) {
+        // jwt 헤더를 파싱한다.
+        Map<String, String> headers = null;
+        try {
+            headers = jwtUtil.parseHeaders(identityToken);
+        } catch (JsonProcessingException e) {
+            log.error("[{}] error: {}", Thread.currentThread().getStackTrace()[1].getMethodName(), e.getMessage());
+            throw new CustomException(StatusCode.OAUTH2_LOGIN_FAILURE);
+        }
+        // 공개키를 생성한다
+        PublicKey publicKey = null;
+        try {
+            publicKey = applePublicKeyGenerator.generatePublicKey(headers, getAppleAuthPublicKey());
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+            log.error("[{}] error: {}", Thread.currentThread().getStackTrace()[1].getMethodName(), e.getMessage());
+            throw new CustomException(StatusCode.OAUTH2_LOGIN_FAILURE);
+        }
+        // 토큰의 signature를 검사하고 Claim 을 반환받는다.
+        Claims tokenClaims = jwtUtil.getTokenClaims(identityToken, publicKey);
+        // Verify that the iss field contains https://appleid.apple.com
+        if (!pkHost.equals(tokenClaims.getIssuer())) {
+            log.error("[{}] error: issue is not correct", Thread.currentThread().getStackTrace()[1].getMethodName());
+            throw new JwtErrorException(StatusCode.INVALID_TOKEN);
+        }
+        // aud 필드 검사
+        if (!tokenClaims.getAudience().contains(clientId)) {
+            log.error("[{}] error: aud is not correct", Thread.currentThread().getStackTrace()[1].getMethodName());
+            throw new JwtErrorException(StatusCode.INVALID_TOKEN);
+        }
+
+        return tokenClaims.getSubject();
+    }
+
+    //애플에 직접 요청해서 PK 받아오기 -> 3개의 PK가 리턴
+    private ApplePublicKeyResponse getAppleAuthPublicKey() {
+        return WebClient.create(pkHost).get()
+                .uri(uribuilder -> uribuilder
+                        .scheme("https")
+                        .path("/auth/keys")
+                        .build(true))
+                .retrieve()
+                .bodyToMono(ApplePublicKeyResponse.class)
+                .block();
+    }
+}

--- a/module-api/src/main/java/com/junior/strategy/oauth2/KakaoOAuth2LoginStrategy.java
+++ b/module-api/src/main/java/com/junior/strategy/oauth2/KakaoOAuth2LoginStrategy.java
@@ -1,0 +1,29 @@
+package com.junior.strategy.oauth2;
+
+import com.junior.dto.oauth2.OAuth2LoginDto;
+import com.junior.dto.oauth2.OAuth2Provider;
+import com.junior.dto.oauth2.OAuth2UserInfo;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import static com.junior.dto.oauth2.OAuth2Provider.KAKAO;
+
+@Slf4j
+@Component
+public class KakaoOAuth2LoginStrategy implements OAuth2MemberStrategy {
+
+    @Override
+    public OAuth2UserInfo getOAuth2UserInfo(OAuth2LoginDto oAuth2LoginDto) {
+        return OAuth2UserInfo.builder()
+                .id(oAuth2LoginDto.id())
+                .nickname(oAuth2LoginDto.nickname())
+                .provider(KAKAO)
+                .build();
+    }
+
+    @Override
+    public boolean isTarget(OAuth2Provider oAuth2Provider) {
+        return oAuth2Provider.equals(KAKAO);
+    }
+
+}

--- a/module-api/src/main/java/com/junior/strategy/oauth2/OAuth2MemberStrategy.java
+++ b/module-api/src/main/java/com/junior/strategy/oauth2/OAuth2MemberStrategy.java
@@ -1,0 +1,12 @@
+package com.junior.strategy.oauth2;
+
+import com.junior.dto.oauth2.OAuth2LoginDto;
+import com.junior.dto.oauth2.OAuth2Provider;
+import com.junior.dto.oauth2.OAuth2UserInfo;
+
+public interface OAuth2MemberStrategy {
+
+    OAuth2UserInfo getOAuth2UserInfo(OAuth2LoginDto oAuth2LoginDto);
+
+    boolean isTarget(OAuth2Provider oAuth2Provider);
+}

--- a/module-api/src/main/java/com/junior/strategy/oauth2/OAuth2MemberStrategyType.java
+++ b/module-api/src/main/java/com/junior/strategy/oauth2/OAuth2MemberStrategyType.java
@@ -1,0 +1,5 @@
+package com.junior.strategy.oauth2;
+
+public enum OAuth2MemberStrategyType {
+    KAKAO, APPLE
+}

--- a/module-api/src/main/resources/application-api-dev.yml
+++ b/module-api/src/main/resources/application-api-dev.yml
@@ -17,6 +17,9 @@ kakao:
   client-id: ${KAKAO_CLIENT_ID}
   client-secret: ${KAKAO_SECRET_KEY}
 
+apple:
+  client-id: ${APPLE_CLIENT_ID}
+  pk-host: ${APPLE_PK_HOST}
 
 cloud:
   aws:

--- a/module-api/src/main/resources/application-api-dev.yml
+++ b/module-api/src/main/resources/application-api-dev.yml
@@ -13,9 +13,10 @@ logging:
   level:
     root: info
 
-apple:
-  client-id: ${APPLE_CLIENT_ID}
-  pk-host: ${APPLE_PK_HOST}
+oauth2:
+  apple:
+    client-id: ${APPLE_CLIENT_ID}
+    pk-host: ${APPLE_PK_HOST}
 
 cloud:
   aws:

--- a/module-api/src/main/resources/application-api-dev.yml
+++ b/module-api/src/main/resources/application-api-dev.yml
@@ -13,10 +13,6 @@ logging:
   level:
     root: info
 
-kakao:
-  client-id: ${KAKAO_CLIENT_ID}
-  client-secret: ${KAKAO_SECRET_KEY}
-
 apple:
   client-id: ${APPLE_CLIENT_ID}
   pk-host: ${APPLE_PK_HOST}

--- a/module-api/src/main/resources/application-api-local.yml
+++ b/module-api/src/main/resources/application-api-local.yml
@@ -17,6 +17,9 @@ kakao:
   client-id: ${KAKAO_CLIENT_ID}
   client-secret: ${KAKAO_SECRET_KEY}
 
+apple:
+  client-id: ${APPLE_CLIENT_ID}
+  pk-host: ${APPLE_PK_HOST}
 
 cloud:
   aws:

--- a/module-api/src/main/resources/application-api-local.yml
+++ b/module-api/src/main/resources/application-api-local.yml
@@ -13,9 +13,11 @@ logging:
   level:
     root: info
 
-apple:
-  client-id: ${APPLE_CLIENT_ID}
-  pk-host: ${APPLE_PK_HOST}
+oauth2:
+  apple:
+    client-id: ${APPLE_CLIENT_ID}
+    pk-host: ${APPLE_PK_HOST}
+
 
 cloud:
   aws:

--- a/module-api/src/main/resources/application-api-local.yml
+++ b/module-api/src/main/resources/application-api-local.yml
@@ -13,10 +13,6 @@ logging:
   level:
     root: info
 
-kakao:
-  client-id: ${KAKAO_CLIENT_ID}
-  client-secret: ${KAKAO_SECRET_KEY}
-
 apple:
   client-id: ${APPLE_CLIENT_ID}
   pk-host: ${APPLE_PK_HOST}

--- a/module-api/src/main/resources/application-api-prod.yml
+++ b/module-api/src/main/resources/application-api-prod.yml
@@ -17,6 +17,9 @@ kakao:
   client-id: ${KAKAO_CLIENT_ID}
   client-secret: ${KAKAO_SECRET_KEY}
 
+apple:
+  client-id: ${APPLE_CLIENT_ID}
+  pk-host: ${APPLE_PK_HOST}
 
 cloud:
   aws:

--- a/module-api/src/main/resources/application-api-prod.yml
+++ b/module-api/src/main/resources/application-api-prod.yml
@@ -13,9 +13,11 @@ logging:
   level:
     root: info
 
-apple:
-  client-id: ${APPLE_CLIENT_ID}
-  pk-host: ${APPLE_PK_HOST}
+oauth2:
+  apple:
+    client-id: ${APPLE_CLIENT_ID}
+    pk-host: ${APPLE_PK_HOST}
+
 
 cloud:
   aws:

--- a/module-api/src/main/resources/application-api-prod.yml
+++ b/module-api/src/main/resources/application-api-prod.yml
@@ -13,10 +13,6 @@ logging:
   level:
     root: info
 
-kakao:
-  client-id: ${KAKAO_CLIENT_ID}
-  client-secret: ${KAKAO_SECRET_KEY}
-
 apple:
   client-id: ${APPLE_CLIENT_ID}
   pk-host: ${APPLE_PK_HOST}

--- a/module-api/src/test/java/com/junior/controller/login/OAuth2ControllerTest.java
+++ b/module-api/src/test/java/com/junior/controller/login/OAuth2ControllerTest.java
@@ -39,7 +39,7 @@ class OAuth2ControllerTest extends BaseControllerTest {
         //given
         MockHttpServletResponse response = new MockHttpServletResponse();
         OAuth2LoginDto oAuth2LoginDto = OAuth2LoginDto.builder()
-                .id(1234L)
+                .id("1234")
                 .nickname("nickname")
                 .build();
         String kakaoProvider = "kakao";

--- a/module-api/src/test/java/com/junior/integration/login/OAuth2IntegrationTest.java
+++ b/module-api/src/test/java/com/junior/integration/login/OAuth2IntegrationTest.java
@@ -68,7 +68,7 @@ public class OAuth2IntegrationTest extends BaseIntegrationTest {
         String kakaoProvider = "kakao";
 
         OAuth2LoginDto oAuth2LoginDto = OAuth2LoginDto.builder()
-                .id(1234L)
+                .id("1234")
                 .nickname("nickname")
                 .build();
 
@@ -108,7 +108,7 @@ public class OAuth2IntegrationTest extends BaseIntegrationTest {
         String appleProvider = "apple";
 
         OAuth2LoginDto oAuth2LoginDto = OAuth2LoginDto.builder()
-                .id(1234L)
+                .id("1234")
                 .nickname("nickname")
                 .build();
 

--- a/module-api/src/test/java/com/junior/service/login/OAuth2ServiceTest.java
+++ b/module-api/src/test/java/com/junior/service/login/OAuth2ServiceTest.java
@@ -52,7 +52,7 @@ class OAuth2ServiceTest {
         //given
         MockHttpServletResponse response = new MockHttpServletResponse();
         OAuth2LoginDto oAuth2LoginDto = OAuth2LoginDto.builder()
-                .id(1234L)
+                .id("1234")
                 .nickname("sample_nickname")
                 .build();
         OAuth2Provider kakaoProvider = OAuth2Provider.KAKAO;
@@ -87,7 +87,7 @@ class OAuth2ServiceTest {
         //given
         MockHttpServletResponse response = new MockHttpServletResponse();
         OAuth2LoginDto oAuth2LoginDto = OAuth2LoginDto.builder()
-                .id(1234L)
+                .id("1234")
                 .nickname("nickname")
                 .build();
         OAuth2Provider kakaoProvider = OAuth2Provider.KAKAO;
@@ -128,7 +128,7 @@ class OAuth2ServiceTest {
         //given
         MockHttpServletResponse response = new MockHttpServletResponse();
         OAuth2LoginDto oAuth2LoginDto = OAuth2LoginDto.builder()
-                .id(1234L)
+                .id("1234")
                 .nickname("nickname")
                 .build();
         OAuth2Provider kakaoProvider = OAuth2Provider.KAKAO;

--- a/module-common/src/main/java/com/junior/exception/CommentNotFoundException.java
+++ b/module-common/src/main/java/com/junior/exception/CommentNotFoundException.java
@@ -3,6 +3,7 @@ package com.junior.exception;
 public class CommentNotFoundException extends RuntimeException {
 
     private StatusCode statusCode;
+
     public CommentNotFoundException(StatusCode statusCode) {
         super(statusCode.getCustomMessage());
         this.statusCode = statusCode;

--- a/module-common/src/main/java/com/junior/exception/CustomException.java
+++ b/module-common/src/main/java/com/junior/exception/CustomException.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 public class CustomException extends RuntimeException {
 
     private StatusCode statusCode;
+
     public CustomException(StatusCode statusCode) {
         super(statusCode.getCustomMessage());
         this.statusCode = statusCode;

--- a/module-common/src/main/java/com/junior/exception/DeletedStoryException.java
+++ b/module-common/src/main/java/com/junior/exception/DeletedStoryException.java
@@ -3,8 +3,9 @@ package com.junior.exception;
 import lombok.Getter;
 
 @Getter
-public class DeletedStoryException extends RuntimeException{
+public class DeletedStoryException extends RuntimeException {
     private StatusCode statusCode;
+
     public DeletedStoryException(StatusCode statusCode) {
         super(statusCode.getCustomMessage());
         this.statusCode = statusCode;

--- a/module-common/src/main/java/com/junior/exception/LikeNotFoundException.java
+++ b/module-common/src/main/java/com/junior/exception/LikeNotFoundException.java
@@ -3,6 +3,7 @@ package com.junior.exception;
 public class LikeNotFoundException extends RuntimeException {
 
     private StatusCode statusCode;
+
     public LikeNotFoundException(StatusCode statusCode) {
         super(statusCode.getCustomMessage());
         this.statusCode = statusCode;

--- a/module-common/src/main/java/com/junior/exception/NotificationNotFoundException.java
+++ b/module-common/src/main/java/com/junior/exception/NotificationNotFoundException.java
@@ -2,6 +2,7 @@ package com.junior.exception;
 
 public class NotificationNotFoundException extends RuntimeException {
     private StatusCode statusCode;
+
     public NotificationNotFoundException(StatusCode statusCode) {
         super(statusCode.getCustomMessage());
         this.statusCode = statusCode;

--- a/module-common/src/main/java/com/junior/exception/PermissionException.java
+++ b/module-common/src/main/java/com/junior/exception/PermissionException.java
@@ -2,6 +2,7 @@ package com.junior.exception;
 
 public class PermissionException extends RuntimeException {
     private StatusCode statusCode;
+
     public PermissionException(StatusCode statusCode) {
         super(statusCode.getCustomMessage());
         this.statusCode = statusCode;

--- a/module-common/src/main/java/com/junior/exception/StatusCode.java
+++ b/module-common/src/main/java/com/junior/exception/StatusCode.java
@@ -83,6 +83,7 @@ public enum StatusCode {
 
     // LOGIN 관련 실패 코드
     ADMIN_LOGIN_FAILURE(401, "LOGIN-ERR-001", "오류가 발생했습니다."),
+    OAUTH2_LOGIN_FAILURE(400, "LOGIN-ERR-002", "오류가 발생했습니다."),
 
     // JWT 관련 성공 코드
     REISSUE_SUCCESS(200, "JWT-SUCCESS-001", "JWT 재발급 완료"),

--- a/module-domain/src/main/java/com/junior/domain/member/SignUpType.java
+++ b/module-domain/src/main/java/com/junior/domain/member/SignUpType.java
@@ -1,5 +1,5 @@
 package com.junior.domain.member;
 
 public enum SignUpType {
-    USERNAME, KAKAO
+    USERNAME, KAKAO, APPLE
 }

--- a/module-domain/src/main/java/com/junior/dto/oauth2/ApplePublicKey.java
+++ b/module-domain/src/main/java/com/junior/dto/oauth2/ApplePublicKey.java
@@ -1,0 +1,9 @@
+package com.junior.dto.oauth2;
+
+public record ApplePublicKey(
+        String kty,
+        String kid,
+        String alg,
+        String n,
+        String e) {
+}

--- a/module-domain/src/main/java/com/junior/dto/oauth2/ApplePublicKeyResponse.java
+++ b/module-domain/src/main/java/com/junior/dto/oauth2/ApplePublicKeyResponse.java
@@ -1,0 +1,15 @@
+package com.junior.dto.oauth2;
+
+import com.junior.exception.JwtErrorException;
+import com.junior.exception.StatusCode;
+
+import java.util.List;
+
+public record ApplePublicKeyResponse(List<ApplePublicKey> keys) {
+    public ApplePublicKey getMatchedKey(String kid, String alg) {
+        return keys.stream()
+                .filter(key -> key.kid().equals(kid) && key.alg().equals(alg))
+                .findAny()
+                .orElseThrow(() -> new JwtErrorException(StatusCode.INVALID_TOKEN));
+    }
+}

--- a/module-domain/src/main/java/com/junior/dto/oauth2/OAuth2LoginDto.java
+++ b/module-domain/src/main/java/com/junior/dto/oauth2/OAuth2LoginDto.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 
 @Builder
 public record OAuth2LoginDto(
-        Long id,
+        String id,
         String nickname
 ) {
 }

--- a/module-domain/src/main/java/com/junior/dto/oauth2/OAuth2Provider.java
+++ b/module-domain/src/main/java/com/junior/dto/oauth2/OAuth2Provider.java
@@ -6,5 +6,5 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum OAuth2Provider {
-    KAKAO
+    KAKAO, APPLE
 }

--- a/module-domain/src/main/java/com/junior/dto/oauth2/OAuth2UserInfo.java
+++ b/module-domain/src/main/java/com/junior/dto/oauth2/OAuth2UserInfo.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 
 @Builder
 public record OAuth2UserInfo(
-        Long id,
+        String id,
         String nickname,
         OAuth2Provider provider
 ) {


### PR DESCRIPTION
- 전략 패턴을 사용하여 소셜로그인 확장에 대비
- 애플 소셜로그인 추가
- 소셜로그인 요청 형식 수정
  - 이제 id는 String으로 받음